### PR TITLE
only output a cc in ControllerMotion if the value has changed enough

### DIFF
--- a/ControllerMotion/Source/PluginProcessor.h
+++ b/ControllerMotion/Source/PluginProcessor.h
@@ -68,6 +68,7 @@ private:
 
     juce::AudioParameterFloat *destinationValue[CBR_CCMOTION_NUM_PARAMS];
     double currentValue[CBR_CCMOTION_NUM_PARAMS];
+    int lastOutputCC[CBR_CCMOTION_NUM_PARAMS];
 
     juce::AudioParameterChoice* phraseBeats;
     juce::AudioParameterInt* firstCCNumber;


### PR DESCRIPTION
Fixes #1 

Tracks the last output CC value for each moving controller, and then uses this to only send a CC event when the value has changed.

This reduces the amount of messages output by the plugin, when motion is slow, or if target knobs are not touched.