### PR TITLE
Fix/3 save and restore plugin state

### DIFF
--- a/ChannelFilter/Source/PluginProcessor.h
+++ b/ChannelFilter/Source/PluginProcessor.h
@@ -64,6 +64,8 @@ private:
 
     int getPhraseBeats ();
 
+    juce::AudioProcessorValueTreeState parameters;
+
     juce::AudioParameterInt* selectedChannel;
     juce::AudioParameterChoice* phraseBeats;
 

--- a/ControllerMotion/Source/PluginProcessor.cpp
+++ b/ControllerMotion/Source/PluginProcessor.cpp
@@ -11,61 +11,94 @@
 //==============================================================================
 MIDIControllerMotionAudioProcessor::MIDIControllerMotionAudioProcessor()
 #ifndef JucePlugin_PreferredChannelConfigurations
-     : AudioProcessor (BusesProperties()
+    :
+    AudioProcessor (BusesProperties()
                      #if ! JucePlugin_IsMidiEffect
                       #if ! JucePlugin_IsSynth
                        .withInput  ("Input",  juce::AudioChannelSet::stereo(), true)
                       #endif
                        .withOutput ("Output", juce::AudioChannelSet::stereo(), true)
                      #endif
-                       )
+                       ),
+        parameters (*this, nullptr, juce::Identifier (JucePlugin_Name),
+            {
+                // Note this plugin allows phrase length 1 beat for "real time" control.
+                // (The clip variation plugins start at 4 beats.)
+                std::make_unique<juce::AudioParameterChoice> (
+                    "phraseBeats", // parameterID
+                    "Phrase length", // parameter name
+                    juce::StringArray( {"1 beat", "4 beats", "8 beats", "16 beats", "32 beats", "64 beats"} ),
+                    2 // default index
+                ),
+            
+            // Moving CC parameters. The number of these params should match CBR_CCMOTION_NUM_PARAMS constant.
+                std::make_unique<juce::AudioParameterFloat> (
+                    "target1", // parameterID
+                    "Target 1", // parameter name
+                    0.0, 1.0, 0.0
+                ),
+                std::make_unique<juce::AudioParameterFloat> (
+                    "target2", // parameterID
+                    "Target 2", // parameter name
+                    0.0, 1.0, 0.0
+                ),
+                std::make_unique<juce::AudioParameterFloat> (
+                    "target3", // parameterID
+                    "Target 3", // parameter name
+                    0.0, 1.0, 0.0
+                ),
+                std::make_unique<juce::AudioParameterFloat> (
+                    "target4", // parameterID
+                    "Target 4", // parameter name
+                    0.0, 1.0, 0.0
+                ),
+            
+                std::make_unique<juce::AudioParameterInt> (
+                    "firstCCNumber", // parameterID
+                    "First CC number", // parameter name
+                    1,
+                    127,
+                    1
+                ),
+                std::make_unique<juce::AudioParameterInt> (
+                    "channelNumber", // parameterID
+                    "Channel", // parameter name
+                    1,
+                    16,
+                    1
+                ),
+            } )
 #endif
 {
     tempoBpm = 120.0;
     lastBufferTimestamp = 0;
     
-    // Note this plugin allows phrase length 1 beat for "real time" control.
-    // (The clip variation plugins start at 4 beats.)
-    addParameter (phraseBeats = new juce::AudioParameterChoice (
-        "phraseBeats", // parameterID
-        "Phrase length", // parameter name
-        juce::StringArray( {"1 beat", "4 beats", "8 beats", "16 beats", "32 beats", "64 beats"} ),
-        2 // default index
-    ));
+    // Assuming it's ok to just cast these to specific param type.
+    phraseBeats = (juce::AudioParameterChoice*)parameters.getParameter("phraseBeats");
+    firstCCNumber = (juce::AudioParameterInt*)parameters.getParameter("firstCCNumber");
+    channelNumber = (juce::AudioParameterInt*)parameters.getParameter("channelNumber");
 
     for (int i=0; i<CBR_CCMOTION_NUM_PARAMS; i++) {
         int controllerNumber = i + 1;
 
         std::ostringstream paramIdentifier;
         paramIdentifier << "target" << controllerNumber;
-        std::ostringstream paramName;
-        paramName << "Target " << controllerNumber;
+//        std::ostringstream paramName;
+//        paramName << "Target " << controllerNumber;
 
         currentValue[i] = 0;
         lastOutputCC[i] = 0;
-        addParameter (destinationValue[i] = new juce::AudioParameterFloat (
-            paramIdentifier.str(), // parameterID
-            paramName.str(), // parameter name
-            0.0,
-            1.0,
-            0.0
-        ));
+//        parameters.createAndAddParameter(
+//            std::make_unique<juce::AudioParameterInt> (
+//                 paramIdentifier.str(), // parameterID
+//                 paramName.str(), // parameter name
+//                 0.0,
+//                 1.0,
+//                 0.0
+//            )
+//        );
+        destinationValue[i] = (juce::AudioParameterFloat*)parameters.getParameter(paramIdentifier.str());
     }
-
-    addParameter (firstCCNumber = new juce::AudioParameterInt (
-        "firstCC", // parameterID
-        "First CC number", // parameter name
-        1,
-        127,
-        1
-    ));
-    addParameter (channelNumber = new juce::AudioParameterInt (
-        "channelNumber", // parameterID
-        "Channel", // parameter name
-        1,
-        16,
-        1
-    ));
 }
 
 double MIDIControllerMotionAudioProcessor::getPhraseBeats ()

--- a/ControllerMotion/Source/PluginProcessor.cpp
+++ b/ControllerMotion/Source/PluginProcessor.cpp
@@ -83,20 +83,9 @@ MIDIControllerMotionAudioProcessor::MIDIControllerMotionAudioProcessor()
 
         std::ostringstream paramIdentifier;
         paramIdentifier << "target" << controllerNumber;
-//        std::ostringstream paramName;
-//        paramName << "Target " << controllerNumber;
 
         currentValue[i] = 0;
         lastOutputCC[i] = 0;
-//        parameters.createAndAddParameter(
-//            std::make_unique<juce::AudioParameterInt> (
-//                 paramIdentifier.str(), // parameterID
-//                 paramName.str(), // parameter name
-//                 0.0,
-//                 1.0,
-//                 0.0
-//            )
-//        );
         destinationValue[i] = (juce::AudioParameterFloat*)parameters.getParameter(paramIdentifier.str());
     }
 }

--- a/ControllerMotion/Source/PluginProcessor.cpp
+++ b/ControllerMotion/Source/PluginProcessor.cpp
@@ -336,15 +336,18 @@ juce::AudioProcessorEditor* MIDIControllerMotionAudioProcessor::createEditor()
 //==============================================================================
 void MIDIControllerMotionAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
-    // You should use this method to store your parameters in the memory block.
-    // You could do that either as raw data, or use the XML or ValueTree classes
-    // as intermediaries to make it easy to save and load complex data.
+    auto state = parameters.copyState();
+    std::unique_ptr<juce::XmlElement> xml (state.createXml());
+    copyXmlToBinary (*xml, destData);
 }
 
 void MIDIControllerMotionAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
-    // You should use this method to restore your parameters from this memory block,
-    // whose contents will have been created by the getStateInformation() call.
+    std::unique_ptr<juce::XmlElement> xmlState (getXmlFromBinary (data, sizeInBytes));
+
+    if (xmlState.get() != nullptr)
+        if (xmlState->hasTagName (parameters.state.getType()))
+            parameters.replaceState (juce::ValueTree::fromXml (*xmlState));
 }
 
 //==============================================================================

--- a/ControllerMotion/Source/PluginProcessor.h
+++ b/ControllerMotion/Source/PluginProcessor.h
@@ -10,6 +10,8 @@
 
 #include <JuceHeader.h>
 
+// These parameters are now hard coded in the constructor initialiser list.
+// If this constant is changed, need to add/remove `target` params accordingly.
 #define CBR_CCMOTION_NUM_PARAMS 4
 
 //==============================================================================
@@ -70,6 +72,8 @@ private:
     double currentValue[CBR_CCMOTION_NUM_PARAMS];
     int lastOutputCC[CBR_CCMOTION_NUM_PARAMS];
 
+    juce::AudioProcessorValueTreeState parameters;
+    
     juce::AudioParameterChoice* phraseBeats;
     juce::AudioParameterInt* firstCCNumber;
     juce::AudioParameterInt* channelNumber;

--- a/NoteFilter/Source/PluginProcessor.cpp
+++ b/NoteFilter/Source/PluginProcessor.cpp
@@ -60,7 +60,6 @@ int MIDIClipVariationsAudioProcessor::getSemitonesPerVariation ()
 {
     int selected = notesPerVariation->getIndex();
     
-    // This looks like pow(2, index) but it's not.
     switch (selected) {
         case 0: return 6;
         case 1: return 12;
@@ -75,15 +74,15 @@ int MIDIClipVariationsAudioProcessor::getPhraseBeats ()
 {
     int selected = phraseBeats->getIndex();
     
-    // This looks like pow(2, index) but it's not.
     switch (selected) {
-        case 0: return 4;
-        case 1: return 8;
-        case 2: return 16;
-        case 3: return 32;
-        case 4: return 64;
+        case 0: return 1;
+        case 1: return 4;
+        case 2: return 8;
+        case 3: return 16;
+        case 4: return 32;
+        case 5: return 64;
     }
-    
+
     return 4;
 }
 

--- a/NoteFilter/Source/PluginProcessor.h
+++ b/NoteFilter/Source/PluginProcessor.h
@@ -65,6 +65,8 @@ private:
     int getSemitonesPerVariation ();
     int getPhraseBeats ();
 
+    juce::AudioProcessorValueTreeState parameters;
+
     juce::AudioParameterInt* selectedVariation;
     juce::AudioParameterChoice* notesPerVariation;
     juce::AudioParameterChoice* phraseBeats;


### PR DESCRIPTION
Fixes #3 

This PR uses [`AudioProcessorValueTreeState`](https://docs.juce.com/master/classAudioProcessorValueTreeState.html) in all plugins as a container for all params, and to persist/unpersist param state.

Also included in this PR:

- All plugins use the same range for `phraseBeats` param - 1 to 64 beats for consistency. This way a MIDI controller can be used to adjust the phrase length in all the plugins consistently.
- Target CC params in `ControllerMotion` are now hard-coded in constructor init list. Previously they were generated using a compile-time constant (no longer practical). If the number of target CCs is changed in future, will need to adjust the `AudioProcessorValueTreeState` construct params appropriately.