### PR TITLE
Output phrase length and current position as MIDI ccs

### DIFF
--- a/ControllerMotion/Source/PluginProcessor.cpp
+++ b/ControllerMotion/Source/PluginProcessor.cpp
@@ -310,9 +310,7 @@ void MIDIControllerMotionAudioProcessor::processBlock (juce::AudioBuffer<float>&
         blockTimeBeats
     );
 
-    if (isPlaying) {
-        outputPhraseInfoAsCCs(currentPhrasePosition, midiMessages);
-    }
+    outputPhraseInfoAsCCs(currentPhrasePosition, isPlaying, midiMessages);
     
     for (int i=0; i<CBR_CCMOTION_NUM_PARAMS; i++) {
         int controllerNumber = i + *firstCCNumber;
@@ -353,7 +351,7 @@ void MIDIControllerMotionAudioProcessor::processBlock (juce::AudioBuffer<float>&
     lastBufferTimestamp = playheadTimeSamples;
 }
 
-void MIDIControllerMotionAudioProcessor::outputPhraseInfoAsCCs (double position, juce::MidiBuffer& midiMessages)
+void MIDIControllerMotionAudioProcessor::outputPhraseInfoAsCCs (double position, bool isPlaying, juce::MidiBuffer& midiMessages)
 {
     juce::AudioParameterInt* ccNumber;
     juce::AudioParameterInt* channel;
@@ -364,7 +362,7 @@ void MIDIControllerMotionAudioProcessor::outputPhraseInfoAsCCs (double position,
     channel = (juce::AudioParameterInt*)parameters.getParameter("outPhrasePosChannel");
     cc = ccNumber->get();
     ch = channel->get();
-    if ( cc ) {
+    if ( isPlaying && cc ) {
         midiMessages.addEvent(
             juce::MidiMessage::controllerEvent(
                 ch,

--- a/ControllerMotion/Source/PluginProcessor.h
+++ b/ControllerMotion/Source/PluginProcessor.h
@@ -64,6 +64,7 @@ private:
     double samplesToBeats (juce::int64 timestamp);
     double beatsToPhrase (double beats);
     bool timeRangeStraddlesPhraseChange (juce::int64 time1, juce::int64 time2);
+    void outputPhraseInfoAsCCs (double position, juce::MidiBuffer& midiMessages);
 
     int getSemitonesPerVariation ();
     double getPhraseBeats ();

--- a/ControllerMotion/Source/PluginProcessor.h
+++ b/ControllerMotion/Source/PluginProcessor.h
@@ -64,7 +64,7 @@ private:
     double samplesToBeats (juce::int64 timestamp);
     double beatsToPhrase (double beats);
     bool timeRangeStraddlesPhraseChange (juce::int64 time1, juce::int64 time2);
-    void outputPhraseInfoAsCCs (double position, juce::MidiBuffer& midiMessages);
+    void outputPhraseInfoAsCCs (double position, bool isPlaying, juce::MidiBuffer& midiMessages);
 
     int getSemitonesPerVariation ();
     double getPhraseBeats ();

--- a/LineToggler/LineToggler.jucer
+++ b/LineToggler/LineToggler.jucer
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<JUCERPROJECT id="otJdPT" name="LineToggler" projectType="audioplug" useAppConfig="0"
+              addUsingNamespaceToJuceHeader="0" displaySplashScreen="1" jucerFormatVersion="1"
+              companyName="cartoonbeats" pluginFormats="buildVST3" pluginCharacteristicsValue="pluginIsMidiEffectPlugin,pluginProducesMidiOut,pluginWantsMidiIn">
+  <MAINGROUP id="vz9zXl" name="LineToggler">
+    <GROUP id="{CEA7FFF1-94CC-BEF5-3A23-2DCF18BC2993}" name="Source">
+      <FILE id="pLQXvr" name="PluginProcessor.cpp" compile="1" resource="0"
+            file="Source/PluginProcessor.cpp"/>
+      <FILE id="TUwomw" name="PluginProcessor.h" compile="0" resource="0"
+            file="Source/PluginProcessor.h"/>
+    </GROUP>
+  </MAINGROUP>
+  <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"/>
+  <EXPORTFORMATS>
+    <XCODE_MAC targetFolder="Builds/MacOSX">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug" targetName="LineToggler"/>
+        <CONFIGURATION isDebug="0" name="Release" targetName="LineToggler"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_audio_basics" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_plugin_client" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_extra" path="../../../JUCE/modules"/>
+      </MODULEPATHS>
+    </XCODE_MAC>
+  </EXPORTFORMATS>
+  <MODULES>
+    <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_plugin_client" showAllCode="1" useLocalCopy="0"
+            useGlobalPath="1"/>
+    <MODULE id="juce_audio_processors" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_core" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_events" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_graphics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_gui_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_gui_extra" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+  </MODULES>
+  <LIVE_SETTINGS>
+    <OSX/>
+  </LIVE_SETTINGS>
+</JUCERPROJECT>

--- a/LineToggler/Source/PluginProcessor.cpp
+++ b/LineToggler/Source/PluginProcessor.cpp
@@ -1,0 +1,281 @@
+/*
+  ==============================================================================
+
+    This file contains the basic framework code for a JUCE plugin processor.
+
+  ==============================================================================
+*/
+
+#include "PluginProcessor.h"
+
+//==============================================================================
+LineTogglerAudioProcessor::LineTogglerAudioProcessor()
+#ifndef JucePlugin_PreferredChannelConfigurations
+    :
+    AudioProcessor (BusesProperties()
+                     #if ! JucePlugin_IsMidiEffect
+                      #if ! JucePlugin_IsSynth
+                       .withInput  ("Input",  juce::AudioChannelSet::stereo(), true)
+                      #endif
+                       .withOutput ("Output", juce::AudioChannelSet::stereo(), true)
+                     #endif
+                       ),
+        parameters (*this, nullptr, juce::Identifier (JucePlugin_Name),
+            {
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable1", // parameterID
+                "Enable line 1", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable2", // parameterID
+                "Enable line 2", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable3", // parameterID
+                "Enable line 3", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable4", // parameterID
+                "Enable line 4", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable5", // parameterID
+                "Enable line 5", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable6", // parameterID
+                "Enable line 6", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable7", // parameterID
+                "Enable line 7", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable8", // parameterID
+                "Enable line 8", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable9", // parameterID
+                "Enable line 9", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable10", // parameterID
+                "Enable line 10", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable11", // parameterID
+                "Enable line 11", // parameter name
+                true
+            ),
+            std::make_unique<juce::AudioParameterBool> (
+                "lineEnable12", // parameterID
+                "Enable line 12", // parameter name
+                true
+            ),
+
+            } )
+#endif
+{
+    for (int i=0; i<CBR_TOGGLELINES_NUM_LINES; i++) {
+        int lineNumber = i + 1;
+
+        std::ostringstream paramIdentifier;
+        paramIdentifier << "lineEnable" << lineNumber;
+        
+        allowLinePlayback[i] = (juce::AudioParameterBool*)parameters.getParameter(paramIdentifier.str());
+    }
+
+}
+
+LineTogglerAudioProcessor::~LineTogglerAudioProcessor()
+{
+}
+
+//==============================================================================
+const juce::String LineTogglerAudioProcessor::getName() const
+{
+    return JucePlugin_Name;
+}
+
+bool LineTogglerAudioProcessor::acceptsMidi() const
+{
+   #if JucePlugin_WantsMidiInput
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+bool LineTogglerAudioProcessor::producesMidi() const
+{
+   #if JucePlugin_ProducesMidiOutput
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+bool LineTogglerAudioProcessor::isMidiEffect() const
+{
+   #if JucePlugin_IsMidiEffect
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+double LineTogglerAudioProcessor::getTailLengthSeconds() const
+{
+    return 0.0;
+}
+
+int LineTogglerAudioProcessor::getNumPrograms()
+{
+    return 1;   // NB: some hosts don't cope very well if you tell them there are 0 programs,
+                // so this should be at least 1, even if you're not really implementing programs.
+}
+
+int LineTogglerAudioProcessor::getCurrentProgram()
+{
+    return 0;
+}
+
+void LineTogglerAudioProcessor::setCurrentProgram (int index)
+{
+}
+
+const juce::String LineTogglerAudioProcessor::getProgramName (int index)
+{
+    return {};
+}
+
+void LineTogglerAudioProcessor::changeProgramName (int index, const juce::String& newName)
+{
+}
+
+//==============================================================================
+void LineTogglerAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
+{
+    // Use this method as the place to do any pre-playback
+    // initialisation that you need..
+}
+
+void LineTogglerAudioProcessor::releaseResources()
+{
+    // When playback stops, you can use this as an opportunity to free up any
+    // spare memory, etc.
+}
+
+#ifndef JucePlugin_PreferredChannelConfigurations
+bool LineTogglerAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
+{
+  #if JucePlugin_IsMidiEffect
+    juce::ignoreUnused (layouts);
+    return true;
+  #else
+    // This is the place where you check if the layout is supported.
+    // In this template code we only support mono or stereo.
+    // Some plugin hosts, such as certain GarageBand versions, will only
+    // load plugins that support stereo bus layouts.
+    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono()
+     && layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
+        return false;
+
+    // This checks if the input layout matches the output layout
+   #if ! JucePlugin_IsSynth
+    if (layouts.getMainOutputChannelSet() != layouts.getMainInputChannelSet())
+        return false;
+   #endif
+
+    return true;
+  #endif
+}
+#endif
+
+void LineTogglerAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
+{
+    outputMidiBuffer.clear();
+
+    const int firstLineNote = 36;
+    
+    // Copy everything to outputMidiBuffer EXCEPT:
+    // - note ons for each line (C1 … B2)
+    for (auto midiMessageIt = midiMessages.begin(); midiMessageIt != midiMessages.end(); ++midiMessageIt) {
+        const juce::MidiMessageMetadata metadata = *midiMessageIt;
+        const juce::MidiMessage m = metadata.getMessage();
+        
+        // Pass all non-note-on events through. We only filter note ons.
+        if (! m.isNoteOn() ) {
+            outputMidiBuffer.addEvent(m, metadata.samplePosition);
+            continue;
+        }
+        
+        const int noteNumber = m.getNoteNumber();
+        const int slotIndex = noteNumber - firstLineNote;
+        
+        // Pass notes below the line range.
+        if ( slotIndex < 0 ) {
+            outputMidiBuffer.addEvent(m, metadata.samplePosition);
+            continue;
+        }
+        // Pass notes above the line range.
+        if ( slotIndex > CBR_TOGGLELINES_NUM_LINES ) {
+            outputMidiBuffer.addEvent(m, metadata.samplePosition);
+            continue;
+        }
+            
+        // If we get to here, the current event is a note-on for a sampler line.
+        // We might mute it if the param is disabled.
+        
+        if ( allowLinePlayback[slotIndex]->get() ) {
+            outputMidiBuffer.addEvent(m, metadata.samplePosition);
+        }
+    }
+    
+    midiMessages.swapWith(outputMidiBuffer);
+}
+
+//==============================================================================
+bool LineTogglerAudioProcessor::hasEditor() const
+{
+    return false;
+}
+
+juce::AudioProcessorEditor* LineTogglerAudioProcessor::createEditor()
+{
+    return 0;
+}
+
+//==============================================================================
+void LineTogglerAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
+{
+    auto state = parameters.copyState();
+    std::unique_ptr<juce::XmlElement> xml (state.createXml());
+    copyXmlToBinary (*xml, destData);
+}
+
+void LineTogglerAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
+{
+    std::unique_ptr<juce::XmlElement> xmlState (getXmlFromBinary (data, sizeInBytes));
+
+    if (xmlState.get() != nullptr)
+        if (xmlState->hasTagName (parameters.state.getType()))
+            parameters.replaceState (juce::ValueTree::fromXml (*xmlState));
+}
+
+//==============================================================================
+// This creates new instances of the plugin..
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
+{
+    return new LineTogglerAudioProcessor();
+}

--- a/LineToggler/Source/PluginProcessor.h
+++ b/LineToggler/Source/PluginProcessor.h
@@ -1,0 +1,69 @@
+/*
+  ==============================================================================
+
+    This file contains the basic framework code for a JUCE plugin processor.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <JuceHeader.h>
+
+// Hard-coded 12 lines for now - one octave of sampler slots
+#define CBR_TOGGLELINES_NUM_LINES 12
+
+//==============================================================================
+/**
+*/
+class LineTogglerAudioProcessor  : public juce::AudioProcessor
+{
+public:
+    //==============================================================================
+    LineTogglerAudioProcessor();
+    ~LineTogglerAudioProcessor() override;
+
+    //==============================================================================
+    void prepareToPlay (double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override;
+
+   #ifndef JucePlugin_PreferredChannelConfigurations
+    bool isBusesLayoutSupported (const BusesLayout& layouts) const override;
+   #endif
+
+    void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+
+    //==============================================================================
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override;
+
+    //==============================================================================
+    const juce::String getName() const override;
+
+    bool acceptsMidi() const override;
+    bool producesMidi() const override;
+    bool isMidiEffect() const override;
+    double getTailLengthSeconds() const override;
+
+    //==============================================================================
+    int getNumPrograms() override;
+    int getCurrentProgram() override;
+    void setCurrentProgram (int index) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
+
+    //==============================================================================
+    void getStateInformation (juce::MemoryBlock& destData) override;
+    void setStateInformation (const void* data, int sizeInBytes) override;
+
+private:
+    //==============================================================================
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LineTogglerAudioProcessor)
+    
+    juce::AudioProcessorValueTreeState parameters;
+    
+    // Store a direct pointer to each param for convenience.
+    juce::AudioParameterBool *allowLinePlayback[CBR_TOGGLELINES_NUM_LINES] ;
+
+    juce::MidiBuffer outputMidiBuffer;
+};


### PR DESCRIPTION
Fixes #8

This PR adds four new parameters:

- MIDI CC number and channel to output current phrase position.
- MIDI CC number and channel to output current phrase length suitable for the first 5 LEDs on a 7-LED meter, as on Traktor Kontrol S4.

Setting the CC to 0 disables output (so this is optional).

And a whole new plugin and feature – LineToggler:

- New VST plugin for enabling / disabling MIDI content of the playing clip.
- Lines of midi data (one per MIDI note, 12x starting at C1 36) can be enabled / disabled via VST parameters – like a MIDI mute.
- When used with single-note sampler clips (for beats / loops in Serato Sample) the mute/unmute will be quantised to the bar/beat (i.e. the note on).

In future this quantise could be specified with control notes in the clip, or as a parameter in the plugin. 
